### PR TITLE
Replace proprietary -moz by standard selector

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -36,7 +36,7 @@ module.exports = function(config) {
       'tests/test-macro-syntax-error.js',
       'tests/test-name-attribute.js',
       'tests/test-old-urls.js',
-      //'tests/test-pre-without-class.js' TODO: Fix this method
+      'tests/test-pre-without-class.js',
       'tests/test-shell-prompts.js',
       'tests/test-span-count.js',
       'tests/test-style-attribute.js',

--- a/lib/pre-without-class.js
+++ b/lib/pre-without-class.js
@@ -15,7 +15,8 @@ exports.preWithoutClass = {
   name: "pre_without_class",
   desc: "pre_without_class_desc",
   check: function checkPreWithoutClass(rootElement) {
-    let presWithoutClass = rootElement.querySelectorAll("pre:-moz-any(:not([class]), [class=''])");
+    //let presWithoutClass = rootElement.querySelectorAll("pre:-moz-any(:not([class]), [class=''])");
+    let presWithoutClass = rootElement.querySelectorAll(":not([class]), [class='']");
     let matches = [];
 
     for (let i = 0; i < presWithoutClass.length; i++) {

--- a/lib/pre-without-class.js
+++ b/lib/pre-without-class.js
@@ -16,7 +16,7 @@ exports.preWithoutClass = {
   desc: "pre_without_class_desc",
   check: function checkPreWithoutClass(rootElement) {
     //let presWithoutClass = rootElement.querySelectorAll("pre:-moz-any(:not([class]), [class=''])");
-    let presWithoutClass = rootElement.querySelectorAll(":not([class]), [class='']");
+    let presWithoutClass = rootElement.querySelectorAll("pre :not([class]), pre [class='']");
     let matches = [];
 
     for (let i = 0; i < presWithoutClass.length; i++) {

--- a/tests/test-pre-without-class.js
+++ b/tests/test-pre-without-class.js
@@ -14,7 +14,8 @@ describe('preWithoutClass', function() {
       '<pre>&lt;tag&gt;</pre>' +
       '<pre id="foo"></pre>' +
       '<pre class="">foo</pre>' +
-      '<pre> \n\r foo</pre>';
+      '<pre> \n\r foo</pre>' + 
+      '<div>Test on non pre</div>';
 
     const expected = [
       {msg: '<pre>foobar;</pre>', type: WARNING},

--- a/tests/test-pre-without-class.js
+++ b/tests/test-pre-without-class.js
@@ -6,24 +6,24 @@ const preWithoutClass = require('../lib/pre-without-class.js').preWithoutClass;
 describe('preWithoutClass', function() {
   it('Should return 3 errors and 4 warnings regarding pre lacking a class', function(done) {
     const str = '<pre class="brush: js"></pre>' +
-           '<pre class="syntaxbox"></pre>' +
-           '<pre>folder/\n  file</pre>' +
-           '<pre>foobar;</pre>' +
-           '<pre>/* comment */\nvar code;</pre>' +
-           '<pre>@rule param {\n  descriptor: value;\n}</pre>' +
-           '<pre>&lt;tag&gt;</pre>' +
-           '<pre id="foo"></pre>' +
-           '<pre class="">foo</pre>' +
+      '<pre class="syntaxbox"></pre>' +
+      '<pre>folder/\n  file</pre>' +
+      '<pre>foobar;</pre>' +
+      '<pre>/* comment */\nvar code;</pre>' +
+      '<pre>@rule param {\n  descriptor: value;\n}</pre>' +
+      '<pre>&lt;tag&gt;</pre>' +
+      '<pre id="foo"></pre>' +
+      '<pre class="">foo</pre>' +
       '<pre> \n\r foo</pre>';
 
     const expected = [
-        {msg: '<pre>foobar;</pre>', type: WARNING},
-        {msg: '<pre>/* comment */\nvar code;</pre>', type: ERROR},
-        {msg: '<pre>@rule param {\n  descriptor: value;\n}</pre>', type: ERROR},
-        {msg: '<pre>&lt;tag&gt;</pre>', type: ERROR},
-        {msg: '<pre id="foo"></pre>', type: WARNING},
-        {msg: '<pre class="">foo</pre>', type: WARNING},
-        {msg: '<pre> \n\n foo</pre>', type: WARNING}
+      {msg: '<pre>foobar;</pre>', type: WARNING},
+      {msg: '<pre>/* comment */\nvar code;</pre>', type: ERROR},
+      {msg: '<pre>@rule param {\n  descriptor: value;\n}</pre>', type: ERROR},
+      {msg: '<pre>&lt;tag&gt;</pre>', type: ERROR},
+      {msg: '<pre id="foo"></pre>', type: WARNING},
+      {msg: '<pre class="">foo</pre>', type: WARNING},
+      {msg: '<pre> \n\n foo</pre>', type: WARNING}
     ];
 
 


### PR DESCRIPTION
Replace proprietary -moz by standard selector to be compatible with a maximum of browser and with the W3C Standard.