### PR TITLE
API headlines: "Exceptions thrown" not marked as invalid

### DIFF
--- a/lib/api-syntax-headlines.js
+++ b/lib/api-syntax-headlines.js
@@ -15,12 +15,17 @@
 
 const ERROR = require('./doctests.js').ERROR;
 
-const disallowedNames = new Map([["returns", "Return value"], ["errors", "Exceptions"],
-    ["errors thrown", "Exceptions"]]);
+const disallowedNames = new Map([
+  ["arguments", "Parameters"],
+  ["returns", "Return value"],
+  ["errors", "Exceptions"],
+  ["errors thrown", "Exceptions"],
+  ["exceptions thrown", "Exceptions"]
+]);
 const validOrder = [
-  new Set(["parameters"]),
+  new Set(["parameters", "arguments"]),
   new Set(["return value", "returns"]),
-  new Set(["exceptions", "errors", "errors thrown"])
+  new Set(["exceptions", "exceptions thrown", "errors", "errors thrown"])
 ];
 
 exports.apiSyntaxHeadlines = {

--- a/tests/test-api-syntax-headlines.js
+++ b/tests/test-api-syntax-headlines.js
@@ -3,15 +3,16 @@ const apiSyntaxHeadlines = require('../lib/api-syntax-headlines.js').apiSyntaxHe
 const ERROR = require('../lib/doctests.js').ERROR;
 
 describe('apiSyntaxHeadlines', function() {
-  it('Should return 4 apiSyntaxHeadlines errors', function(done) {
+  it('Should return 5 apiSyntaxHeadlines errors', function(done) {
     const str = '<h2 id="Syntax">Syntax</h2>' +
-      '<h3>Errors</h3>' +
+      '<h3>Exceptions thrown</h3>' +
       '<h3>Returns</h3>' +
-      '<h3>Parameters</h3>';
+      '<h3>Arguments</h3>';
 
     const expected = [
-      {msg: "invalid_headline_name", msgParams: ["Errors"], type: ERROR},
+      {msg: "invalid_headline_name", msgParams: ["Exception thrown"], type: ERROR},
       {msg: "invalid_headline_name", msgParams: ["Returns"], type: ERROR},
+      {msg: "invalid_headline_name", msgParams: ["Arguments"], type: ERROR},
       {msg: "invalid_headline_order", type: ERROR},
       {msg: "invalid_headline_order", type: ERROR}
     ];
@@ -21,7 +22,31 @@ describe('apiSyntaxHeadlines', function() {
       {msg: "invalid_headline_order", type: ERROR}
     ];
 
-    
+
+    let rootElement = document.createElement("body");
+    rootElement.innerHTML = str;
+
+    let results = apiSyntaxHeadlines.check(rootElement);
+
+    results.forEach((element, index) => {
+      if(element.msg != expected[index].msg || element.type != expected[index].type)
+        done(Error('Expected : ' + JSON.stringify(expected[index]) + ' got : ' + JSON.stringify(element)));
+    });
+
+    done();
+  });
+
+  it('Should return 1 Error regarding apiSyntaxHeadlines errors', function(done) {
+    const str = '<h2 id="Syntax">Syntax</h2>' +
+      '<h3>Return value</h3>' +
+      '<h3>Errors thrown</h3>';
+
+    const expected = [
+      {msg: "invalid_headline_name", msgParams: ["Errors thrown"], type: ERROR}
+    ];
+
+    const expectedAfterFixing = [];
+
     let rootElement = document.createElement("body");
     rootElement.innerHTML = str;
 


### PR DESCRIPTION
Ported from https://github.com/Elchi3/mdn-doc-tests/pull/217