### PR TITLE
Do not select children of <pre>

### DIFF
--- a/lib/pre-without-class.js
+++ b/lib/pre-without-class.js
@@ -16,7 +16,7 @@ exports.preWithoutClass = {
   desc: "pre_without_class_desc",
   check: function checkPreWithoutClass(rootElement) {
     //let presWithoutClass = rootElement.querySelectorAll("pre:-moz-any(:not([class]), [class=''])");
-    let presWithoutClass = rootElement.querySelectorAll("pre :not([class]), pre [class='']");
+    let presWithoutClass = rootElement.querySelectorAll("pre:not([class]), pre[class='']");
     let matches = [];
 
     for (let i = 0; i < presWithoutClass.length; i++) {

--- a/tests/test-pre-without-class.js
+++ b/tests/test-pre-without-class.js
@@ -15,7 +15,8 @@ describe('preWithoutClass', function() {
       '<pre id="foo"></pre>' +
       '<pre class="">foo</pre>' +
       '<pre> \n\r foo</pre>' + 
-      '<div>Test on non pre</div>';
+      '<div>Test on non pre</div>' +
+      '<pre class="syntaxbox"><div>Test</div></pre>';
 
     const expected = [
       {msg: '<pre>foobar;</pre>', type: WARNING},


### PR DESCRIPTION
Fix #35 

" " is a CSS selector indicating to look at the children which we don't want in this case.